### PR TITLE
ArgumentError: wrong number of arguments (given 1, expected 0)

### DIFF
--- a/lib/store_model/ext/parent_assignment.rb
+++ b/lib/store_model/ext/parent_assignment.rb
@@ -9,7 +9,9 @@ module StoreModel
       assign_parent_to_singular_store_model(attribute)
       return unless attribute.is_a?(Array)
 
-      attribute.each(&method(:assign_parent_to_singular_store_model))
+      # Do not use &method here or it will break if the model has a method attribute
+      # See https://github.com/DmitryTsepelev/store_model/issues/121
+      attribute.each { |a| assign_parent_to_singular_store_model(a) }
     end
 
     def assign_parent_to_singular_store_model(item)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -3,7 +3,7 @@
 ActiveRecord::Schema.define(version: 2019_02_216_153105) do
   create_table :products do |t|
     t.string :name
-    t.string :method
+    t.string :method # Reproduces #121: https://github.com/DmitryTsepelev/store_model/issues/121
     t.json :configuration, default: {}
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -3,6 +3,7 @@
 ActiveRecord::Schema.define(version: 2019_02_216_153105) do
   create_table :products do |t|
     t.string :name
+    t.string :method
     t.json :configuration, default: {}
   end
 end


### PR DESCRIPTION
This happens if a model has a `method` attribute, so the model's attribute is called instead of `Object.method`. This is just a quick fix until we can rename the attributes in our models, since this won't be merged into the main repo, as explained here: https://github.com/DmitryTsepelev/store_model/pull/122#issuecomment-1168584550